### PR TITLE
✨ Feature - 2.12 현재 비밀번호 확인 API 구현

### DIFF
--- a/http/auth/AuthControllerHttpRequest.http
+++ b/http/auth/AuthControllerHttpRequest.http
@@ -63,13 +63,13 @@ Authorization: Bearer {{access_token}}
 
 ### 2.4 기본 임시 회원가입 - 유학생
 // @no-log
-@email_user = "jake991110@naver.com"
+@email_user = "jangelliot0404@dgu.ac.kr"
 POST {{host_url}}/v1/auth/sign-up
 Content-Type: application/json
 
 {
   "password" : "{{auth.API_2_4_USER.password}}",
-  "email" : "kangseung1110@gmail.com",
+  "email" : {{email_user}},
   "account_type" : "USER"
 }
 
@@ -159,13 +159,13 @@ Content-Type: application/json
 
 ### 2.7 이메일 인증코드 검증 - 유학생
 // @no-log
-@authentication_code_user = "992560"
+@authentication_code_user = "073484"
 PATCH {{host_url}}/v1/auth/validations/authentication-code
 Content-Type: application/json
 
 {
   "id" : "{{auth.API_2_7_USER.id}}",
-  "email" : "kangseung1110@gmail.com",
+  "email" : {{email_user}},
   "authentication_code" : {{authentication_code_user}}
 }
 
@@ -228,4 +228,14 @@ Content-Type: application/json
 {
   "current_password": "{{auth.API_2_11.current_password}}",
   "new_password": "{{auth.API_2_11.new_password}}"
+}
+
+### 2.12 현재 비밀번호 확인
+// @no-log
+POST {{host_url}}/v1/auth/validations/password
+Authorization: Bearer {{access_token}}
+Content-Type: application/json
+
+{
+  "password": "{{auth.API_2_12.password}}"
 }

--- a/src/main/java/com/inglo/giggle/core/constant/Constants.java
+++ b/src/main/java/com/inglo/giggle/core/constant/Constants.java
@@ -128,7 +128,9 @@ public class Constants {
      */
     public static List<String> NO_NEED_AUTH_URLS = List.of(
             // Authentication/Authorization
-            "/v1/auth/validations/**",
+            "/v1/auth/validations/authentication-code",
+            "/v1/auth/validations/email",
+            "/v1/auth/validations/id",
             "/v1/auth/reissue/token",
             "/v1/auth/reissue/authentication-code",
             "/v1/auth/reissue/password",

--- a/src/main/java/com/inglo/giggle/security/application/controller/AuthController.java
+++ b/src/main/java/com/inglo/giggle/security/application/controller/AuthController.java
@@ -37,6 +37,7 @@ public class AuthController {
     private final DeleteAccountUseCase deleteAccountUseCase;
     private final UpdateDeviceTokenUseCase updateDeviceTokenUseCase;
     private final ChangePasswordUseCase changePasswordUseCase;
+    private final ValidatePasswordUseCase validatePasswordUseCase;
 
     /**
      * 1.3 JWT 재발급
@@ -183,5 +184,16 @@ public class AuthController {
     ) {
         changePasswordUseCase.execute(accountId, requestDto);
         return ResponseDto.ok(null);
+    }
+
+    /**
+     * 2.12 현재 비밀번호 확인
+     */
+    @PostMapping("/validations/password")
+    public ResponseDto<?> validatePassword(
+            @RequestBody @Valid ValidatePasswordRequestDto requestDto,
+            @AccountID UUID accountId
+    ) {
+        return ResponseDto.ok(validatePasswordUseCase.execute(accountId, requestDto));
     }
 }

--- a/src/main/java/com/inglo/giggle/security/application/dto/request/ValidatePasswordRequestDto.java
+++ b/src/main/java/com/inglo/giggle/security/application/dto/request/ValidatePasswordRequestDto.java
@@ -1,0 +1,11 @@
+package com.inglo.giggle.security.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record ValidatePasswordRequestDto(
+        @JsonProperty("password")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/com/inglo/giggle/security/application/dto/response/ValidatePasswordResponseDto.java
+++ b/src/main/java/com/inglo/giggle/security/application/dto/response/ValidatePasswordResponseDto.java
@@ -1,0 +1,27 @@
+package com.inglo.giggle.security.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.inglo.giggle.core.dto.SelfValidating;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ValidatePasswordResponseDto extends SelfValidating<ValidatePasswordResponseDto> {
+    @JsonProperty("is_valid")
+    @NotNull(message = "비밀번호 유효성은 필수입니다.")
+    private final Boolean isValid;
+
+    @Builder
+    public ValidatePasswordResponseDto(Boolean isValid) {
+        this.isValid = isValid;
+
+        validateSelf();
+    }
+
+    public static ValidatePasswordResponseDto of(Boolean isValid) {
+        return ValidatePasswordResponseDto.builder()
+                .isValid(isValid)
+                .build();
+    }
+}

--- a/src/main/java/com/inglo/giggle/security/application/service/ValidatePasswordService.java
+++ b/src/main/java/com/inglo/giggle/security/application/service/ValidatePasswordService.java
@@ -1,0 +1,38 @@
+package com.inglo.giggle.security.application.service;
+
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import com.inglo.giggle.security.application.dto.request.ValidatePasswordRequestDto;
+import com.inglo.giggle.security.application.dto.response.ValidatePasswordResponseDto;
+import com.inglo.giggle.security.application.usecase.ValidatePasswordUseCase;
+import com.inglo.giggle.security.domain.mysql.Account;
+import com.inglo.giggle.security.repository.mysql.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ValidatePasswordService implements ValidatePasswordUseCase {
+
+    private final AccountRepository accountRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public ValidatePasswordResponseDto execute(UUID accountId, ValidatePasswordRequestDto requestDto) {
+
+        // Account 조회
+        Account account = accountRepository.findById(accountId).
+                orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_ACCOUNT));
+
+        return ValidatePasswordResponseDto.of(
+                bCryptPasswordEncoder.matches(
+                        requestDto.password(),
+                        account.getPassword()
+                )
+        );
+    }
+}

--- a/src/main/java/com/inglo/giggle/security/application/usecase/ValidatePasswordUseCase.java
+++ b/src/main/java/com/inglo/giggle/security/application/usecase/ValidatePasswordUseCase.java
@@ -1,0 +1,12 @@
+package com.inglo.giggle.security.application.usecase;
+
+import com.inglo.giggle.core.annotation.bean.UseCase;
+import com.inglo.giggle.security.application.dto.request.ValidatePasswordRequestDto;
+import com.inglo.giggle.security.application.dto.response.ValidatePasswordResponseDto;
+
+import java.util.UUID;
+
+@UseCase
+public interface ValidatePasswordUseCase {
+    ValidatePasswordResponseDto execute(UUID accountId, ValidatePasswordRequestDto requestDto);
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #179 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 마이페이지의 민감 정보 수정 시 필요한, 현재 비밀번호 확인 API를 구현했습니다.
- Constant에 적용되어있던 /v1/auth/validation/** 와일드카드를 제거하고, 분리했습니다.
- API 로컬 테스트를 완료했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
