### PR TITLE
✨ Feature - Account에 Admin Role 추가, Banner API 구현

### DIFF
--- a/http/auth/AuthControllerHttpRequest.http
+++ b/http/auth/AuthControllerHttpRequest.http
@@ -24,6 +24,19 @@ password={{auth.API_1_1_OWNER.password}}
     client.global.set("refresh_token", response.body.data.refresh_token);
 %}
 
+### 1.1 사용자 로그인 - 관리자
+// @no-log
+POST {{host_url}}/v1/auth/login
+Content-Type: application/x-www-form-urlencoded
+
+serial_id={{auth.API_1_1_ADMIN.serial_id}}&
+password={{auth.API_1_1_ADMIN.password}}
+
+> {%
+    client.global.set("access_token", response.body.data.access_token);
+    client.global.set("refresh_token", response.body.data.refresh_token);
+%}
+
 ### 1.2 사용자 로그아웃
 // @no-log
 POST {{host_url}}/v1/auth/logout
@@ -63,7 +76,7 @@ Authorization: Bearer {{access_token}}
 
 ### 2.4 기본 임시 회원가입 - 유학생
 // @no-log
-@email_user = "jake991110@naver.com"
+@email_user = "jangelliot0404@dgu.ac.kr"
 POST {{host_url}}/v1/auth/sign-up
 Content-Type: application/json
 
@@ -128,7 +141,7 @@ Content-Type: multipart/form-data; boundary=boundary
 Content-Disposition: form-data; name="image"; filename="image.png"
 Content-Type: image/png
 
-< /Users/jjuuuunnii/Desktop/image.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 Content-Disposition: form-data; name="body"
@@ -159,7 +172,7 @@ Content-Type: application/json
 
 ### 2.7 이메일 인증코드 검증 - 유학생
 // @no-log
-@authentication_code_user = "127587"
+@authentication_code_user = "094155"
 PATCH {{host_url}}/v1/auth/validations/authentication-code
 Content-Type: application/json
 
@@ -175,7 +188,7 @@ Content-Type: application/json
 
 ### 2.7 이메일 인증코드 검증 - 고용주
 // @no-log
-@authentication_code_owner = "260687"
+@authentication_code_owner = "751331"
 PATCH {{host_url}}/v1/auth/validations/authentication-code
 Content-Type: application/json
 

--- a/http/banner/BannerControllerHttpRequest.http
+++ b/http/banner/BannerControllerHttpRequest.http
@@ -1,0 +1,29 @@
+### 12.1 배너 요약 조회하기
+// @no-log
+GET {{host_url}}/v1/guests/banners/overviews
+Authorization: Bearer {{access_token}}
+
+### 12.2 배너 상세 조회하기
+// @no-log
+GET {{host_url}}/v1/guests/banners/1/details
+
+### 12.3 배너 등록하기
+// @no-log
+POST {{host_url}}/v1/banners
+Content-Type: multipart/form-data; boundary=boundary
+Authorization: Bearer {{access_token}}
+
+--boundary
+Content-Disposition: form-data; name="body"
+Content-Type: application/json
+
+{
+  "content" : "배너 내용",
+  "role" : "USER"
+}
+
+--boundary
+Content-Disposition: form-data; name="image"; filename="image.png"
+Content-Type: image/png
+
+< /Users/kyeom/Desktop/team13.png

--- a/http/banner/BannerControllerHttpRequest.http
+++ b/http/banner/BannerControllerHttpRequest.http
@@ -1,17 +1,28 @@
-### 12.1 배너 요약 조회하기
+### 12.1 (게스트) 배너 요약 조회하기
 // @no-log
 GET {{host_url}}/v1/guests/banners/overviews
 Authorization: Bearer {{access_token}}
 
-### 12.2 배너 상세 조회하기
+### 12.2 (게스트) 배너 상세 조회하기
 // @no-log
 GET {{host_url}}/v1/guests/banners/1/details
 
-### 12.3 배너 등록하기
+### 12.3 (유학생/고용주/관리자) 배너 요약 조회하기
+// @no-log
+GET {{host_url}}/v1/banners/overviews
+Authorization: Bearer {{access_token}}
+
+### 12.4 (유학생/고용주/관리자) 배너 상세 조회하기
+// @no-log
+GET {{host_url}}/v1/banners/1/details
+Authorization: Bearer {{access_token}}'
+
+### 12.5 배너 등록하기
 // @no-log
 POST {{host_url}}/v1/banners
 Content-Type: multipart/form-data; boundary=boundary
 Authorization: Bearer {{access_token}}
+
 
 --boundary
 Content-Disposition: form-data; name="body"
@@ -27,3 +38,8 @@ Content-Disposition: form-data; name="image"; filename="image.png"
 Content-Type: image/png
 
 < /Users/kyeom/Desktop/team13.png
+
+### 12.6 배너 삭제하기
+// @no-log
+DELETE {{host_url}}/v1/banners/1
+Authorization: Bearer {{access_token}}

--- a/k8s/api-server.yaml
+++ b/k8s/api-server.yaml
@@ -208,6 +208,16 @@ spec:
                 secretKeyRef:
                   name: application-yml-secret
                   key: push-token-delete-url
+            - name: GIGGLE_ADMIN_ID
+              valueFrom:
+                secretKeyRef:
+                  name: application-yml-secret
+                  key: giggle-admin-id
+            - name: GIGGLE_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: application-yml-secret
+                  key: giggle-admin-password
       volumes:
         - name: template-volume
           configMap:

--- a/src/main/java/com/inglo/giggle/account/domain/Admin.java
+++ b/src/main/java/com/inglo/giggle/account/domain/Admin.java
@@ -1,0 +1,54 @@
+package com.inglo.giggle.account.domain;
+
+import com.inglo.giggle.security.domain.mysql.Account;
+import com.inglo.giggle.security.domain.type.ESecurityProvider;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "admins")
+@PrimaryKeyJoinColumn(
+        name = "account_id",
+        foreignKey = @ForeignKey(name = "fk_admin_account")
+)
+@DiscriminatorValue("ADMIN")
+@DynamicUpdate
+public class Admin extends Account {
+
+    /* -------------------------------------------- */
+    /* Methods ------------------------------------ */
+    /* -------------------------------------------- */
+
+    @Builder
+    public Admin(
+            ESecurityProvider provider,
+            String serialId,
+            String password,
+            String email,
+            String profileImgUrl,
+            String phoneNumber,
+            Boolean marketingAllowed,
+            Boolean notificationAllowed
+    ) {
+        super(provider, serialId, password, email, profileImgUrl, phoneNumber, marketingAllowed, notificationAllowed);
+    }
+
+    @Override
+    public ESecurityRole getRole() {
+        return ESecurityRole.ADMIN;
+    }
+
+    @Override
+    public String getName() {
+        return "관리자";
+    }
+
+}
+

--- a/src/main/java/com/inglo/giggle/address/domain/Address.java
+++ b/src/main/java/com/inglo/giggle/address/domain/Address.java
@@ -17,16 +17,16 @@ public class Address {
     @Column(name = "address_name", length = 50)
     private String addressName;
 
-    @Column(name = "region_1depth_name", length = 10)
+    @Column(name = "region_1depth_name", length = 50)
     private String region1DepthName;
 
-    @Column(name = "region_2depth_name", length = 10)
+    @Column(name = "region_2depth_name", length = 50)
     private String region2DepthName;
 
-    @Column(name = "region_3depth_name", length = 10)
+    @Column(name = "region_3depth_name", length = 50)
     private String region3DepthName;
 
-    @Column(name = "region_4depth_name", length = 10)
+    @Column(name = "region_4depth_name", length = 50)
     private String region4DepthName;
 
     @Column(name = "address_detail", length = 100)

--- a/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
@@ -23,7 +23,7 @@ public class BannerAdminCommandV1Controller {
 
 
     /**
-     * 12.3 (어드민) 배너 생성하기
+     * 12.5 (관리자) 배너 생성하기
      */
     @PostMapping(value = "", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseDto<Void> createBanner(
@@ -36,7 +36,7 @@ public class BannerAdminCommandV1Controller {
     }
 
     /**
-     * 12.3 (어드민) 배너 삭제하기
+     * 12.6 (관리자) 배너 삭제하기
      */
     @DeleteMapping("/{bannerId}")
     public ResponseDto<Void> deleteBanner(

--- a/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
@@ -1,0 +1,50 @@
+package com.inglo.giggle.banner.application.controller.command;
+
+import com.inglo.giggle.banner.application.dto.request.CreateAdminBannerRequestDto;
+import com.inglo.giggle.banner.application.usecase.CreateAdminBannerUseCase;
+import com.inglo.giggle.banner.application.usecase.DeleteAdminBannerUseCase;
+import com.inglo.giggle.core.annotation.security.AccountID;
+import com.inglo.giggle.core.dto.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/banners")
+public class BannerAdminCommandV1Controller {
+
+    private final CreateAdminBannerUseCase createAdminBannerUseCase;
+    private final DeleteAdminBannerUseCase deleteAdminBannerUseCase;
+
+
+    /**
+     * 12.3 (어드민) 배너 생성하기
+     */
+    @PostMapping(value = "", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseDto<Void> createBanner(
+            @AccountID UUID accountId,
+            @RequestPart(value = "image") MultipartFile image,
+            @RequestPart(value = "body") @Valid CreateAdminBannerRequestDto requestDto
+    ) {
+        createAdminBannerUseCase.execute(accountId, image, requestDto);
+        return ResponseDto.created(null);
+    }
+
+    /**
+     * 12.3 (어드민) 배너 삭제하기
+     */
+    @DeleteMapping("/{bannerId}")
+    public ResponseDto<Void> deleteBanner(
+            @AccountID UUID accountId,
+            @PathVariable Long bannerId
+    ) {
+        deleteAdminBannerUseCase.execute(accountId, bannerId);
+        return ResponseDto.ok(null);
+    }
+
+}

--- a/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerGuestQueryV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerGuestQueryV1Controller.java
@@ -1,0 +1,40 @@
+package com.inglo.giggle.banner.application.controller.query;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
+import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
+import com.inglo.giggle.banner.application.usecase.ReadGuestBannerDetailUseCase;
+import com.inglo.giggle.banner.application.usecase.ReadGuestBannerOverviewUseCase;
+import com.inglo.giggle.core.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/guests/banners")
+public class BannerGuestQueryV1Controller {
+    private final ReadGuestBannerOverviewUseCase readGuestBannerOverviewUseCase;
+    private final ReadGuestBannerDetailUseCase readGuestBannerDetailUseCase;
+
+    /**
+     * 12.1 (게스트) 배너 요약 조회하기
+     */
+    @GetMapping("/overviews")
+    public ResponseDto<ReadBannerOverviewResponseDto> readBannerOverview() {
+
+        return ResponseDto.ok(readGuestBannerOverviewUseCase.execute());
+    }
+
+    /**
+     * 12.2 (게스트) 배너 상세 조회하기
+     */
+    @GetMapping("/{id}/details")
+    public ResponseDto<ReadBannerDetailResponseDto> readBannerDetail(
+            @PathVariable Long id
+    ) {
+        return ResponseDto.ok(readGuestBannerDetailUseCase.execute(id));
+    }
+
+}

--- a/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerQueryV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerQueryV1Controller.java
@@ -4,53 +4,41 @@ import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponse
 import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
 import com.inglo.giggle.banner.application.usecase.ReadBannerDetailUseCase;
 import com.inglo.giggle.banner.application.usecase.ReadBannerOverviewUseCase;
-import com.inglo.giggle.core.annotation.security.AccountID;
-import com.inglo.giggle.core.constant.Constants;
+import com.inglo.giggle.core.annotation.security.Role;
 import com.inglo.giggle.core.dto.ResponseDto;
-import com.inglo.giggle.core.exception.error.ErrorCode;
-import com.inglo.giggle.core.exception.type.CommonException;
-import com.inglo.giggle.core.utility.HeaderUtil;
-import com.inglo.giggle.school.application.dto.response.ReadUserSchoolBriefResponseDto;
-import com.inglo.giggle.school.application.dto.response.ReadUserSchoolDetailResponseDto;
-import com.inglo.giggle.school.application.usecase.ReadUserSchoolBriefUseCase;
-import com.inglo.giggle.school.application.usecase.ReadUserSchoolDetailUseCase;
-import jakarta.servlet.http.HttpServletRequest;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
-
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/guests/banners")
+@RequestMapping("/v1/banners")
 public class BannerQueryV1Controller {
     private final ReadBannerOverviewUseCase readBannerOverviewUseCase;
     private final ReadBannerDetailUseCase readBannerDetailUseCase;
 
     /**
-     * 12.1 (유학생/게스트/고용주) 배너 요약 조회하기
+     * 12.3 (유학생/고용주/관리자) 배너 요약 조회하기
      */
     @GetMapping("/overviews")
     public ResponseDto<ReadBannerOverviewResponseDto> readBannerOverview(
-            HttpServletRequest request
+            @Role ESecurityRole role
     ) {
-        String accessToken = HeaderUtil.refineHeader(request, Constants.AUTHORIZATION_HEADER, Constants.BEARER_PREFIX)
-                .orElse(null);
-
-        return ResponseDto.ok(readBannerOverviewUseCase.execute(accessToken));
+        return ResponseDto.ok(readBannerOverviewUseCase.execute(role));
     }
 
     /**
-     * 12.2 (유학생/게스트/고용주) 배너 상세 조회하기
+     * 12.4 (유학생/고용주/관리자) 배너 상세 조회하기
      */
     @GetMapping("/{id}/details")
     public ResponseDto<ReadBannerDetailResponseDto> readBannerDetail(
+            @Role ESecurityRole role,
             @PathVariable Long id
     ) {
-        return ResponseDto.ok(readBannerDetailUseCase.execute(id));
+        return ResponseDto.ok(readBannerDetailUseCase.execute(role, id));
     }
 
 }

--- a/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerQueryV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/query/BannerQueryV1Controller.java
@@ -1,0 +1,56 @@
+package com.inglo.giggle.banner.application.controller.query;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
+import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
+import com.inglo.giggle.banner.application.usecase.ReadBannerDetailUseCase;
+import com.inglo.giggle.banner.application.usecase.ReadBannerOverviewUseCase;
+import com.inglo.giggle.core.annotation.security.AccountID;
+import com.inglo.giggle.core.constant.Constants;
+import com.inglo.giggle.core.dto.ResponseDto;
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import com.inglo.giggle.core.utility.HeaderUtil;
+import com.inglo.giggle.school.application.dto.response.ReadUserSchoolBriefResponseDto;
+import com.inglo.giggle.school.application.dto.response.ReadUserSchoolDetailResponseDto;
+import com.inglo.giggle.school.application.usecase.ReadUserSchoolBriefUseCase;
+import com.inglo.giggle.school.application.usecase.ReadUserSchoolDetailUseCase;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/guests/banners")
+public class BannerQueryV1Controller {
+    private final ReadBannerOverviewUseCase readBannerOverviewUseCase;
+    private final ReadBannerDetailUseCase readBannerDetailUseCase;
+
+    /**
+     * 12.1 (유학생/게스트/고용주) 배너 요약 조회하기
+     */
+    @GetMapping("/overviews")
+    public ResponseDto<ReadBannerOverviewResponseDto> readBannerOverview(
+            HttpServletRequest request
+    ) {
+        String accessToken = HeaderUtil.refineHeader(request, Constants.AUTHORIZATION_HEADER, Constants.BEARER_PREFIX)
+                .orElse(null);
+
+        return ResponseDto.ok(readBannerOverviewUseCase.execute(accessToken));
+    }
+
+    /**
+     * 12.2 (유학생/게스트/고용주) 배너 상세 조회하기
+     */
+    @GetMapping("/{id}/details")
+    public ResponseDto<ReadBannerDetailResponseDto> readBannerDetail(
+            @PathVariable Long id
+    ) {
+        return ResponseDto.ok(readBannerDetailUseCase.execute(id));
+    }
+
+}

--- a/src/main/java/com/inglo/giggle/banner/application/dto/request/CreateAdminBannerRequestDto.java
+++ b/src/main/java/com/inglo/giggle/banner/application/dto/request/CreateAdminBannerRequestDto.java
@@ -1,0 +1,17 @@
+package com.inglo.giggle.banner.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateAdminBannerRequestDto(
+        @JsonProperty("content")
+        @NotBlank(message = "배너 내용은 필수입니다.")
+        String content,
+
+        @JsonProperty("role")
+        @NotNull(message = "배너 권한은 필수입니다.")
+        ESecurityRole role
+) {
+}

--- a/src/main/java/com/inglo/giggle/banner/application/dto/response/ReadBannerDetailResponseDto.java
+++ b/src/main/java/com/inglo/giggle/banner/application/dto/response/ReadBannerDetailResponseDto.java
@@ -1,0 +1,40 @@
+package com.inglo.giggle.banner.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.core.dto.SelfValidating;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReadBannerDetailResponseDto extends SelfValidating<ReadBannerDetailResponseDto> {
+
+    @JsonProperty("id")
+    private final Long id;
+
+    @JsonProperty("img_url")
+    private final String imgUrl;
+
+    @JsonProperty("content")
+    private final String content;
+
+    @Builder
+    public ReadBannerDetailResponseDto(Long id, String imgUrl, String content) {
+        this.id = id;
+        this.imgUrl = imgUrl;
+        this.content = content;
+        this.validateSelf();
+    }
+
+    public static ReadBannerDetailResponseDto fromEntity(Banner banner) {
+        return ReadBannerDetailResponseDto.builder()
+                .id(banner.getId())
+                .imgUrl(banner.getImgUrl())
+                .content(banner.getContent())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/inglo/giggle/banner/application/dto/response/ReadBannerOverviewResponseDto.java
+++ b/src/main/java/com/inglo/giggle/banner/application/dto/response/ReadBannerOverviewResponseDto.java
@@ -1,0 +1,51 @@
+package com.inglo.giggle.banner.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.core.dto.SelfValidating;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReadBannerOverviewResponseDto extends SelfValidating<ReadBannerOverviewResponseDto> {
+
+    @JsonProperty("banner_list")
+    private final List<BannerListDto> schoolList;
+
+    @Builder
+    public ReadBannerOverviewResponseDto(List<BannerListDto> schoolList) {
+        this.schoolList = schoolList;
+        this.validateSelf();
+    }
+
+    @Getter
+    public static class BannerListDto extends SelfValidating<BannerListDto> {
+        @JsonProperty("id")
+        private final Long id;
+
+        @JsonProperty("img_url")
+        private final String imgUrl;
+
+        @Builder
+        public BannerListDto(Long id, String imgUrl) {
+            this.id = id;
+            this.imgUrl = imgUrl;
+            this.validateSelf();
+        }
+
+        public static BannerListDto fromEntity(Banner banner) {
+            return BannerListDto.builder()
+                    .id(banner.getId())
+                    .imgUrl(banner.getImgUrl())
+                    .build();
+        }
+    }
+
+    public static ReadBannerOverviewResponseDto fromEntities(List<Banner> banners) {
+        return ReadBannerOverviewResponseDto.builder()
+                .schoolList(banners.stream().map(BannerListDto::fromEntity).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
@@ -40,7 +40,7 @@ public class CreateAdminBannerService implements CreateAdminBannerUseCase {
         // 계정 타입 유효성 검사
         accountService.checkAdminValidation(account);
 
-        String imgUrl = s3Util.uploadImageFile(image, account.getSerialId(), EImageType.Banner_IMG);
+        String imgUrl = s3Util.uploadImageFile(image, account.getSerialId(), EImageType.BANNER_IMG);
 
         Banner banner = Banner.builder()
                 .imgUrl(imgUrl)

--- a/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
@@ -1,0 +1,53 @@
+package com.inglo.giggle.banner.application.service;
+
+import com.inglo.giggle.banner.application.dto.request.CreateAdminBannerRequestDto;
+import com.inglo.giggle.banner.application.usecase.CreateAdminBannerUseCase;
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.banner.repository.mysql.BannerRepository;
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import com.inglo.giggle.core.type.EImageType;
+import com.inglo.giggle.core.utility.S3Util;
+import com.inglo.giggle.security.domain.mysql.Account;
+import com.inglo.giggle.security.domain.service.AccountService;
+import com.inglo.giggle.security.repository.mysql.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CreateAdminBannerService implements CreateAdminBannerUseCase {
+
+    private final AccountRepository accountRepository;
+    private final BannerRepository bannerRepository;
+
+    private final AccountService accountService;
+
+    private final S3Util s3Util;
+
+    @Override
+    @Transactional
+    public void execute(UUID accountId, MultipartFile image, CreateAdminBannerRequestDto requestDto) {
+
+        // Account 조회
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
+
+        // 계정 타입 유효성 검사
+        accountService.checkAdminValidation(account);
+
+        String imgUrl = s3Util.uploadImageFile(image, account.getSerialId(), EImageType.Banner_IMG);
+
+        Banner banner = Banner.builder()
+                .imgUrl(imgUrl)
+                .content(requestDto.content())
+                .role(requestDto.role())
+                .build();
+
+        bannerRepository.save(banner);
+    }
+}

--- a/src/main/java/com/inglo/giggle/banner/application/service/DeleteAdminBannerService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/DeleteAdminBannerService.java
@@ -1,0 +1,36 @@
+package com.inglo.giggle.banner.application.service;
+
+import com.inglo.giggle.banner.application.usecase.DeleteAdminBannerUseCase;
+import com.inglo.giggle.banner.repository.mysql.BannerRepository;
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import com.inglo.giggle.security.domain.mysql.Account;
+import com.inglo.giggle.security.domain.service.AccountService;
+import com.inglo.giggle.security.repository.mysql.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAdminBannerService implements DeleteAdminBannerUseCase {
+
+    private final AccountRepository accountRepository;
+    private final BannerRepository bannerRepository;
+
+    private final AccountService accountService;
+
+    @Override
+    public void execute(UUID accountId, Long bannerId) {
+
+        // Account 조회
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
+
+        // 계정 타입 유효성 검사
+        accountService.checkAdminValidation(account);
+
+        bannerRepository.deleteById(bannerId);
+    }
+}

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerDetailService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerDetailService.java
@@ -1,0 +1,30 @@
+package com.inglo.giggle.banner.application.service;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
+import com.inglo.giggle.banner.application.usecase.ReadBannerDetailUseCase;
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.banner.repository.mysql.BannerRepository;
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReadBannerDetailService implements ReadBannerDetailUseCase {
+    private final BannerRepository bannerRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReadBannerDetailResponseDto execute(Long bannerId) {
+
+        // Banner 조회
+        Banner banner = bannerRepository.findById(bannerId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
+
+        return ReadBannerDetailResponseDto.fromEntity(banner);
+    }
+
+
+}

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerOverviewService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerOverviewService.java
@@ -30,7 +30,7 @@ public class ReadBannerOverviewService implements ReadBannerOverviewUseCase {
                 ESecurityRole.USER : ESecurityRole.fromString(jsonWebTokenUtil.validateToken(accessToken).get(Constants.ACCOUNT_ROLE_CLAIM_NAME, String.class));
 
         if (role == ESecurityRole.ADMIN) {
-            List<Banner> banners = bannerRepository.find();
+            List<Banner> banners = bannerRepository.findAll();
             return ReadBannerOverviewResponseDto.fromEntities(banners);
         }
 

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerOverviewService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerOverviewService.java
@@ -1,0 +1,41 @@
+package com.inglo.giggle.banner.application.service;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
+import com.inglo.giggle.banner.application.usecase.ReadBannerOverviewUseCase;
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.banner.repository.mysql.BannerRepository;
+import com.inglo.giggle.core.constant.Constants;
+import com.inglo.giggle.core.utility.JsonWebTokenUtil;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReadBannerOverviewService implements ReadBannerOverviewUseCase {
+
+    private final BannerRepository bannerRepository;
+
+    private final JsonWebTokenUtil jsonWebTokenUtil;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReadBannerOverviewResponseDto execute(String accessToken) {
+
+        // Role에 따른 배너 조회
+        ESecurityRole role = accessToken == null ?
+                ESecurityRole.USER : ESecurityRole.fromString(jsonWebTokenUtil.validateToken(accessToken).get(Constants.ACCOUNT_ROLE_CLAIM_NAME, String.class));
+
+        if (role == ESecurityRole.ADMIN) {
+            List<Banner> banners = bannerRepository.find();
+            return ReadBannerOverviewResponseDto.fromEntities(banners);
+        }
+
+        List<Banner> banners = bannerRepository.findByRole(role);
+
+        return ReadBannerOverviewResponseDto.fromEntities(banners);
+    }
+}

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadGuestBannerDetailService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadGuestBannerDetailService.java
@@ -1,7 +1,7 @@
 package com.inglo.giggle.banner.application.service;
 
 import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
-import com.inglo.giggle.banner.application.usecase.ReadBannerDetailUseCase;
+import com.inglo.giggle.banner.application.usecase.ReadGuestBannerDetailUseCase;
 import com.inglo.giggle.banner.domain.Banner;
 import com.inglo.giggle.banner.repository.mysql.BannerRepository;
 import com.inglo.giggle.core.exception.error.ErrorCode;
@@ -13,24 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ReadBannerDetailService implements ReadBannerDetailUseCase {
+public class ReadGuestBannerDetailService implements ReadGuestBannerDetailUseCase {
     private final BannerRepository bannerRepository;
 
     @Override
     @Transactional(readOnly = true)
-    public ReadBannerDetailResponseDto execute(ESecurityRole role, Long bannerId) {
+    public ReadBannerDetailResponseDto execute(Long bannerId) {
 
         // Banner 조회
         Banner banner = bannerRepository.findById(bannerId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
 
-        // 관리자인지 확인
-        if (role == ESecurityRole.ADMIN) {
-            return ReadBannerDetailResponseDto.fromEntity(banner);
-        }
-
         // Banner 권한 확인
-        if (!banner.getRole().equals(role)) {
+        if (!banner.getRole().equals(ESecurityRole.USER)) {
             throw new CommonException(ErrorCode.ACCESS_DENIED);
         }
 

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadGuestBannerOverviewService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadGuestBannerOverviewService.java
@@ -1,7 +1,7 @@
 package com.inglo.giggle.banner.application.service;
 
 import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
-import com.inglo.giggle.banner.application.usecase.ReadBannerOverviewUseCase;
+import com.inglo.giggle.banner.application.usecase.ReadGuestBannerOverviewUseCase;
 import com.inglo.giggle.banner.domain.Banner;
 import com.inglo.giggle.banner.repository.mysql.BannerRepository;
 import com.inglo.giggle.security.domain.type.ESecurityRole;
@@ -13,20 +13,15 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class ReadBannerOverviewService implements ReadBannerOverviewUseCase {
+public class ReadGuestBannerOverviewService implements ReadGuestBannerOverviewUseCase {
 
     private final BannerRepository bannerRepository;
 
     @Override
     @Transactional(readOnly = true)
-    public ReadBannerOverviewResponseDto execute(ESecurityRole role) {
+    public ReadBannerOverviewResponseDto execute() {
 
-        if (role == ESecurityRole.ADMIN) {
-            List<Banner> banners = bannerRepository.findAll();
-            return ReadBannerOverviewResponseDto.fromEntities(banners);
-        }
-
-        List<Banner> banners = bannerRepository.findByRole(role);
+        List<Banner> banners = bannerRepository.findByRole(ESecurityRole.USER);
 
         return ReadBannerOverviewResponseDto.fromEntities(banners);
     }

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/CreateAdminBannerUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/CreateAdminBannerUseCase.java
@@ -1,0 +1,12 @@
+package com.inglo.giggle.banner.application.usecase;
+
+import com.inglo.giggle.banner.application.dto.request.CreateAdminBannerRequestDto;
+import com.inglo.giggle.core.annotation.bean.UseCase;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@UseCase
+public interface CreateAdminBannerUseCase {
+    void execute(UUID accountId, MultipartFile image, CreateAdminBannerRequestDto requestDto);
+}

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/DeleteAdminBannerUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/DeleteAdminBannerUseCase.java
@@ -1,0 +1,10 @@
+package com.inglo.giggle.banner.application.usecase;
+
+import com.inglo.giggle.core.annotation.bean.UseCase;
+
+import java.util.UUID;
+
+@UseCase
+public interface DeleteAdminBannerUseCase {
+    void execute(UUID accountId, Long bannerId);
+}

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/ReadBannerDetailUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/ReadBannerDetailUseCase.java
@@ -1,0 +1,7 @@
+package com.inglo.giggle.banner.application.usecase;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
+
+public interface ReadBannerDetailUseCase {
+    ReadBannerDetailResponseDto execute(Long bannerId);
+}

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/ReadBannerOverviewUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/ReadBannerOverviewUseCase.java
@@ -1,0 +1,9 @@
+package com.inglo.giggle.banner.application.usecase;
+
+import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
+import com.inglo.giggle.core.annotation.bean.UseCase;
+
+@UseCase
+public interface ReadBannerOverviewUseCase {
+    ReadBannerOverviewResponseDto execute(String accessToken);
+}

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/ReadGuestBannerDetailUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/ReadGuestBannerDetailUseCase.java
@@ -2,9 +2,8 @@ package com.inglo.giggle.banner.application.usecase;
 
 import com.inglo.giggle.banner.application.dto.response.ReadBannerDetailResponseDto;
 import com.inglo.giggle.core.annotation.bean.UseCase;
-import com.inglo.giggle.security.domain.type.ESecurityRole;
 
 @UseCase
-public interface ReadBannerDetailUseCase {
-    ReadBannerDetailResponseDto execute(ESecurityRole role, Long bannerId);
+public interface ReadGuestBannerDetailUseCase {
+    ReadBannerDetailResponseDto execute(Long bannerId);
 }

--- a/src/main/java/com/inglo/giggle/banner/application/usecase/ReadGuestBannerOverviewUseCase.java
+++ b/src/main/java/com/inglo/giggle/banner/application/usecase/ReadGuestBannerOverviewUseCase.java
@@ -2,9 +2,9 @@ package com.inglo.giggle.banner.application.usecase;
 
 import com.inglo.giggle.banner.application.dto.response.ReadBannerOverviewResponseDto;
 import com.inglo.giggle.core.annotation.bean.UseCase;
-import com.inglo.giggle.security.domain.type.ESecurityRole;
 
 @UseCase
-public interface ReadBannerOverviewUseCase {
-    ReadBannerOverviewResponseDto execute(ESecurityRole role);
+public interface ReadGuestBannerOverviewUseCase {
+
+    ReadBannerOverviewResponseDto execute();
 }

--- a/src/main/java/com/inglo/giggle/banner/domain/Banner.java
+++ b/src/main/java/com/inglo/giggle/banner/domain/Banner.java
@@ -1,0 +1,56 @@
+package com.inglo.giggle.banner.domain;
+
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "banners")
+public class Banner {
+
+    /* -------------------------------------------- */
+    /* Default Column ----------------------------- */
+    /* -------------------------------------------- */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /* -------------------------------------------- */
+    /* Information Column ------------------------- */
+    /* -------------------------------------------- */
+    @Column(name = "img_url", length = 320, nullable = false)
+    private String imgUrl;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ESecurityRole role;
+
+    /* -------------------------------------------- */
+    /* Timestamp Column --------------------------- */
+    /* -------------------------------------------- */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDate createdAt;
+
+    /* -------------------------------------------- */
+    /* Methods ------------------------------------ */
+    /* -------------------------------------------- */
+    @Builder
+    public Banner(String imgUrl, String content, ESecurityRole role) {
+        this.imgUrl = imgUrl;
+        this.content = content;
+        this.role = role;
+        this.createdAt = LocalDate.now();
+    }
+
+}

--- a/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
+++ b/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
@@ -1,0 +1,18 @@
+package com.inglo.giggle.banner.repository.mysql;
+
+import com.inglo.giggle.banner.domain.Banner;
+import com.inglo.giggle.school.domain.School;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long>{
+    List<Banner> findByRole(ESecurityRole role);
+
+    @Query("SELECT b FROM Banner b")
+    List<Banner> find();
+}

--- a/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
+++ b/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
@@ -1,10 +1,8 @@
 package com.inglo.giggle.banner.repository.mysql;
 
 import com.inglo.giggle.banner.domain.Banner;
-import com.inglo.giggle.school.domain.School;
 import com.inglo.giggle.security.domain.type.ESecurityRole;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,7 +10,4 @@ import java.util.List;
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long>{
     List<Banner> findByRole(ESecurityRole role);
-
-    @Query("SELECT b FROM Banner b")
-    List<Banner> find();
 }

--- a/src/main/java/com/inglo/giggle/core/annotation/security/Role.java
+++ b/src/main/java/com/inglo/giggle/core/annotation/security/Role.java
@@ -1,0 +1,9 @@
+package com.inglo.giggle.core.annotation.security;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Role {
+}

--- a/src/main/java/com/inglo/giggle/core/config/WebMVCConfig.java
+++ b/src/main/java/com/inglo/giggle/core/config/WebMVCConfig.java
@@ -1,5 +1,6 @@
 package com.inglo.giggle.core.config;
 
+import com.inglo.giggle.core.resolver.HttpRoleArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import com.inglo.giggle.core.constant.Constants;
 import com.inglo.giggle.core.interceptor.pre.HttpAccountIDInterceptor;
@@ -19,11 +20,13 @@ public class WebMVCConfig implements WebMvcConfigurer {
 
     private final HttpAccountIDInterceptor httpAccountIDInterceptor;
     private final HttpAccountIDArgumentResolver httpAccountIDArgumentResolver;
+    private final HttpRoleArgumentResolver httpRoleArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         WebMvcConfigurer.super.addArgumentResolvers(resolvers);
         resolvers.add(httpAccountIDArgumentResolver);
+        resolvers.add(httpRoleArgumentResolver);
     }
 
     @Override

--- a/src/main/java/com/inglo/giggle/core/resolver/HttpRoleArgumentResolver.java
+++ b/src/main/java/com/inglo/giggle/core/resolver/HttpRoleArgumentResolver.java
@@ -4,6 +4,7 @@ import com.inglo.giggle.core.annotation.security.Role;
 import com.inglo.giggle.core.exception.error.ErrorCode;
 import com.inglo.giggle.core.exception.type.CommonException;
 import com.inglo.giggle.security.domain.type.ESecurityRole;
+import com.inglo.giggle.security.info.CustomUserPrincipal;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,19 +29,11 @@ public class HttpRoleArgumentResolver implements HandlerMethodArgumentResolver {
             ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
-    ) throws Exception {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || authentication.getAuthorities().isEmpty()) {
-            throw new CommonException(ErrorCode.ACCESS_DENIED);
-        }
-        String authority = authentication.getAuthorities().iterator().next().getAuthority();
-
-        if(authority.startsWith("ROLE_")) {
-            authority = authority.substring(5);
-        }
+    ) {
         try {
-            return ESecurityRole.fromString(authority);
-        } catch (IllegalArgumentException ex) {
+            CustomUserPrincipal principal = (CustomUserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            return principal.getRole();
+        } catch (Exception ex) {
             throw new CommonException(ErrorCode.ACCESS_DENIED);
         }
     }

--- a/src/main/java/com/inglo/giggle/core/resolver/HttpRoleArgumentResolver.java
+++ b/src/main/java/com/inglo/giggle/core/resolver/HttpRoleArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.inglo.giggle.core.resolver;
+
+import com.inglo.giggle.core.annotation.security.Role;
+import com.inglo.giggle.core.exception.error.ErrorCode;
+import com.inglo.giggle.core.exception.type.CommonException;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class HttpRoleArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(ESecurityRole.class)
+                && parameter.hasParameterAnnotation(Role.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getAuthorities().isEmpty()) {
+            throw new CommonException(ErrorCode.ACCESS_DENIED);
+        }
+        String authority = authentication.getAuthorities().iterator().next().getAuthority();
+
+        if(authority.startsWith("ROLE_")) {
+            authority = authority.substring(5);
+        }
+        try {
+            return ESecurityRole.fromString(authority);
+        } catch (IllegalArgumentException ex) {
+            throw new CommonException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/inglo/giggle/core/type/EImageType.java
+++ b/src/main/java/com/inglo/giggle/core/type/EImageType.java
@@ -9,7 +9,7 @@ public enum EImageType {
     USER_PROFILE_IMG("유저 프로필", "USER_PROFILE"),
     OWNER_PROFILE_IMG("고용주 프로필", "OWNER_PROFILE"),
     COMPANY_IMG("회사 이미지", "COMPANY_IMAGE"),
-    Banner_IMG("배너 이미지", "BANNER_IMAGE")
+    BANNER_IMG("배너 이미지", "BANNER_IMAGE")
 
     ;
 
@@ -21,7 +21,7 @@ public enum EImageType {
             case "USER_PROFILE" -> USER_PROFILE_IMG;
             case "OWNER_PROFILE" -> OWNER_PROFILE_IMG;
             case "COMPANY_IMAGE" -> COMPANY_IMG;
-            case "BANNER_IMAGE" -> Banner_IMG;
+            case "BANNER_IMAGE" -> BANNER_IMG;
             default -> throw new IllegalArgumentException("이미지 타입이 잘못되었습니다.");
         };
     }

--- a/src/main/java/com/inglo/giggle/core/type/EImageType.java
+++ b/src/main/java/com/inglo/giggle/core/type/EImageType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum EImageType {
     USER_PROFILE_IMG("유저 프로필", "USER_PROFILE"),
     OWNER_PROFILE_IMG("고용주 프로필", "OWNER_PROFILE"),
-    COMPANY_IMG("회사 이미지", "COMPANY_IMAGE")
+    COMPANY_IMG("회사 이미지", "COMPANY_IMAGE"),
+    Banner_IMG("배너 이미지", "BANNER_IMAGE")
 
     ;
 
@@ -20,6 +21,7 @@ public enum EImageType {
             case "USER_PROFILE" -> USER_PROFILE_IMG;
             case "OWNER_PROFILE" -> OWNER_PROFILE_IMG;
             case "COMPANY_IMAGE" -> COMPANY_IMG;
+            case "BANNER_IMAGE" -> Banner_IMG;
             default -> throw new IllegalArgumentException("이미지 타입이 잘못되었습니다.");
         };
     }

--- a/src/main/java/com/inglo/giggle/core/utility/S3Util.java
+++ b/src/main/java/com/inglo/giggle/core/utility/S3Util.java
@@ -49,7 +49,7 @@ public class S3Util {
                 case USER_PROFILE_IMG -> "users/" + "account_" + serialId + "/" + "profile_img/" + fileName;
                 case OWNER_PROFILE_IMG -> "owners/" + "account_" + serialId + "/" + "icon_img/" + fileName;
                 case COMPANY_IMG -> "companies/" + "account_" + serialId + "/" + "company_img/" + fileName;
-                case Banner_IMG -> "banners/" + "banner_" + serialId + "/" + "banner_img/" + fileName;
+                case BANNER_IMG -> "banners/" + "banner_" + serialId + "/" + "banner_img/" + fileName;
             };
 
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.getInputStream(), objectMetadata);

--- a/src/main/java/com/inglo/giggle/core/utility/S3Util.java
+++ b/src/main/java/com/inglo/giggle/core/utility/S3Util.java
@@ -49,6 +49,7 @@ public class S3Util {
                 case USER_PROFILE_IMG -> "users/" + "account_" + serialId + "/" + "profile_img/" + fileName;
                 case OWNER_PROFILE_IMG -> "owners/" + "account_" + serialId + "/" + "icon_img/" + fileName;
                 case COMPANY_IMG -> "companies/" + "account_" + serialId + "/" + "company_img/" + fileName;
+                case Banner_IMG -> "banners/" + "banner_" + serialId + "/" + "banner_img/" + fileName;
             };
 
             PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, file.getInputStream(), objectMetadata);

--- a/src/main/java/com/inglo/giggle/posting/application/service/CreateUserJobPostingService.java
+++ b/src/main/java/com/inglo/giggle/posting/application/service/CreateUserJobPostingService.java
@@ -65,7 +65,7 @@ public class CreateUserJobPostingService implements CreateUserJobPostingUseCase 
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
 
         // 지원 기간이 지난 공고인지 확인
-        if(jobPosting.getRecruitmentDeadLine().isBefore(LocalDate.now())) {
+        if((jobPosting.getRecruitmentDeadLine() != null) && jobPosting.getRecruitmentDeadLine().isBefore(LocalDate.now())) {
             throw new CommonException(ErrorCode.EXPIRED_JOB_POSTING);
         }
 

--- a/src/main/java/com/inglo/giggle/security/config/AdminConfig.java
+++ b/src/main/java/com/inglo/giggle/security/config/AdminConfig.java
@@ -1,0 +1,55 @@
+package com.inglo.giggle.security.config;
+
+import com.inglo.giggle.account.domain.Admin;
+import com.inglo.giggle.security.domain.mysql.Account;
+import com.inglo.giggle.security.domain.type.ESecurityProvider;
+import com.inglo.giggle.security.repository.mysql.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class AdminConfig {
+
+    @Value("${admin.id}")
+    private String superUserSerialId;
+
+    @Value("${admin.password}")
+    private String superUserPassword;
+
+    private final AccountRepository accountRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Bean
+    public ApplicationRunner createSuperUser() {
+        return args -> {
+
+            accountRepository.findBySerialId(superUserSerialId).ifPresentOrElse(
+                    user -> {
+                        log.info("관리자가 이미 생성되어 있습니다.");
+                    },
+                    () -> {
+                        Account superUser = Admin.builder()
+                                .provider(ESecurityProvider.DEFAULT)
+                                .serialId(superUserSerialId)
+                                .password(passwordEncoder.encode(superUserPassword))
+                                .email("")
+                                .profileImgUrl("default.jpg")
+                                .phoneNumber("010-0000-0000")
+                                .marketingAllowed(false)
+                                .notificationAllowed(false)
+                                .build();
+                        accountRepository.save(superUser);
+                        log.info("관리자가 생성되었습니다.");
+                    }
+            );
+        };
+    }
+}
+

--- a/src/main/java/com/inglo/giggle/security/config/SecurityConfig.java
+++ b/src/main/java/com/inglo/giggle/security/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(configurer -> configurer
                         .requestMatchers(Constants.NO_NEED_AUTH_URLS.toArray(String[]::new)).permitAll()
-                        .requestMatchers(Constants.USER_URLS.toArray(String[]::new)).hasAnyRole("USER", "OWNER")
+                        .requestMatchers(Constants.USER_URLS.toArray(String[]::new)).hasAnyRole("USER", "OWNER", "ADMIN")
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/inglo/giggle/security/domain/service/AccountService.java
+++ b/src/main/java/com/inglo/giggle/security/domain/service/AccountService.java
@@ -52,4 +52,9 @@ public class AccountService {
         if (!account.getRole().equals(ESecurityRole.OWNER))
             throw new CommonException(ErrorCode.INVALID_ACCOUNT_TYPE);
     }
+
+    public void checkAdminValidation(Account account) {
+        if (!account.getRole().equals(ESecurityRole.ADMIN))
+            throw new CommonException(ErrorCode.INVALID_ACCOUNT_TYPE);
+    }
 }

--- a/src/main/java/com/inglo/giggle/security/domain/type/ESecurityRole.java
+++ b/src/main/java/com/inglo/giggle/security/domain/type/ESecurityRole.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ESecurityRole {
 
     USER("유학생", "USER", "ROLE_USER"),
-    OWNER("점주", "OWNER", "ROLE_OWNER")
+    OWNER("점주", "OWNER", "ROLE_OWNER"),
+    ADMIN("관리자", "ADMIN", "ROLE_ADMIN")
 
     ;
 
@@ -20,6 +21,7 @@ public enum ESecurityRole {
         return switch (value.toUpperCase()) {
             case "USER" -> USER;
             case "OWNER" -> OWNER;
+            case "ADMIN" -> ADMIN;
             default -> throw new IllegalArgumentException("Security Role이 잘못되었습니다.");
         };
     }

--- a/src/main/java/com/inglo/giggle/security/handler/login/DefaultLoginSuccessHandler.java
+++ b/src/main/java/com/inglo/giggle/security/handler/login/DefaultLoginSuccessHandler.java
@@ -2,12 +2,12 @@ package com.inglo.giggle.security.handler.login;
 
 import com.inglo.giggle.core.utility.HttpServletUtil;
 import com.inglo.giggle.core.utility.JsonWebTokenUtil;
+import com.inglo.giggle.security.application.dto.response.DefaultJsonWebTokenDto;
 import com.inglo.giggle.security.application.usecase.LoginByDefaultUseCase;
+import com.inglo.giggle.security.info.CustomUserPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import com.inglo.giggle.security.application.dto.response.DefaultJsonWebTokenDto;
-import com.inglo.giggle.security.info.CustomUserPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/application-krampoline.yml
+++ b/src/main/resources/application-krampoline.yml
@@ -19,7 +19,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:
@@ -110,3 +110,7 @@ push:
 logging:
   level:
     org.docx4j: WARN
+
+admin:
+  id: ${GIGGLE_ADMIN_ID}
+  password: ${GIGGLE_ADMIN_PASSWORD}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #198 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- Admin 구현
어드민은 Account를 상속받되, 다른 어떠한 필드도 가지지 않습니다.
getRole을 통해 ADMIN Role을 반환합니다.
```
package com.inglo.giggle.account.domain;

import com.inglo.giggle.security.domain.mysql.Account;
import com.inglo.giggle.security.domain.type.ESecurityProvider;
import com.inglo.giggle.security.domain.type.ESecurityRole;
import jakarta.persistence.*;
import lombok.AccessLevel;
import lombok.Builder;
import lombok.Getter;
import lombok.NoArgsConstructor;
import org.hibernate.annotations.DynamicUpdate;

@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(name = "admins")
@PrimaryKeyJoinColumn(
        name = "account_id",
        foreignKey = @ForeignKey(name = "fk_admin_account")
)
@DiscriminatorValue("ADMIN")
@DynamicUpdate
public class Admin extends Account {

    /* -------------------------------------------- */
    /* Methods ------------------------------------ */
    /* -------------------------------------------- */

    @Builder
    public Admin(
            ESecurityProvider provider,
            String serialId,
            String password,
            String email,
            String profileImgUrl,
            String phoneNumber,
            Boolean marketingAllowed,
            Boolean notificationAllowed
    ) {
        super(provider, serialId, password, email, profileImgUrl, phoneNumber, marketingAllowed, notificationAllowed);
    }

    @Override
    public ESecurityRole getRole() {
        return ESecurityRole.ADMIN;
    }

    @Override
    public String getName() {
        return "관리자";
    }

}


```
- Admin 생성 로직 구현
서버가 시작할 때, 현재 어드민이 존재하는지의 여부를 먼저 확인하고, 있다면 skip, 없다면 생성합니다.
```
@Configuration
@RequiredArgsConstructor
@Slf4j
public class AdminConfig {

    @Value("${admin.id}")
    private String superUserSerialId;

    @Value("${admin.password}")
    private String superUserPassword;

    private final AccountRepository accountRepository;
    private final BCryptPasswordEncoder passwordEncoder;

    @Bean
    public ApplicationRunner createSuperUser() {
        return args -> {

            accountRepository.findBySerialId(superUserSerialId).ifPresentOrElse(
                    user -> {
                        log.info("관리자가 이미 생성되어 있습니다.");
                    },
                    () -> {
                        Account superUser = Admin.builder()
                                .provider(ESecurityProvider.DEFAULT)
                                .serialId(superUserSerialId)
                                .password(passwordEncoder.encode(superUserPassword))
                                .email("")
                                .profileImgUrl("default.jpg")
                                .phoneNumber("010-0000-0000")
                                .marketingAllowed(false)
                                .notificationAllowed(false)
                                .build();
                        accountRepository.save(superUser);
                        log.info("관리자가 생성되었습니다.");
                    }
            );
        };
    }
}
```

admin의 아이디와 비밀번호는 yml로 관리되며, notion에 업데이트 해놓았습니다.
크램폴린 환경에도 secret으로 생성해두었으며, pods 생성 시 secret으로부터 yml에 주입받습니다.

- Banner 도메인 구현
img_url (대표 사진)
content(HTML형식의 내용)
role(보여지는 대상)
으로 구성되어있습니다. dbdiagram에도 반영해두었습니다.
```
package com.inglo.giggle.banner.domain;

import com.inglo.giggle.security.domain.type.ESecurityRole;
import jakarta.persistence.*;
import lombok.AccessLevel;
import lombok.Builder;
import lombok.Getter;
import lombok.NoArgsConstructor;

import java.time.LocalDate;

@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(name = "banners")
public class Banner {

    /* -------------------------------------------- */
    /* Default Column ----------------------------- */
    /* -------------------------------------------- */
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    /* -------------------------------------------- */
    /* Information Column ------------------------- */
    /* -------------------------------------------- */
    @Column(name = "img_url", length = 320, nullable = false)
    private String imgUrl;

    @Lob
    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
    private String content;

    @Column(name = "role", nullable = false)
    @Enumerated(EnumType.STRING)
    private ESecurityRole role;

    /* -------------------------------------------- */
    /* Timestamp Column --------------------------- */
    /* -------------------------------------------- */
    @Column(name = "created_at", nullable = false, updatable = false)
    private LocalDate createdAt;

    /* -------------------------------------------- */
    /* Methods ------------------------------------ */
    /* -------------------------------------------- */
    @Builder
    public Banner(String imgUrl, String content, ESecurityRole role) {
        this.imgUrl = imgUrl;
        this.content = content;
        this.role = role;
        this.createdAt = LocalDate.now();
    }

}
```

- Banner CRD 로직 구현
12.1 배너 요약 조회
12.2 배너 상세 조회
12.3 배너 생성(관리자)
12.4 배너 삭제

위 네 API를 구현 완료했습니다.
12.1 배너 요약 조회의 경우, GUEST + USER 는 유학생과 관련된 배너를 조회하며, OWNER의 경우 고용주와 관련된 배너를 조회합니다. ADMIN의 경우 모든 배너를 조회합니다.

배너 상세조회의 경우, 따로 권한처리를 하진 않았습니다. (배너 조회에까지 굳이 필요없다고 생각해서...)

배너 생성의 경우, 관리자만 가능합니다. 이미지파일 + 내용 + role 을 입력받아 생성합니다.

배너 삭제 또한 관리자만 가능합니다. id를 기반으로한 삭제를 진행합니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
없다면 N/A를 작성해주세요.
- [ ]  dev 업데이트 → @jjuuuunnii  코드리뷰 이후 바로 반영 예정
- [ ]  prod 업데이트 → 은지가 필요한 작업(현재 prod에서의 스샷)이 모두 끝난 이후에 반영 예정

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
Prod 환경은 아직 업데이트를 하지 않고 기다리라고 합니다. 현재 ddl-auto를 create로 변경해놓은 상태라(DB 변경 존재하므로), 
prod에는 은지가 필요한 스크린샷 작업이 끝난 이후에 반영 예정입니다. 