### PR TITLE
🔨 Fix - 공고 등록 및 수정 시, 비자 다중으로 받도록 수정

### DIFF
--- a/http/TestScenarioOne.http
+++ b/http/TestScenarioOne.http
@@ -53,7 +53,7 @@ Content-Type: application/json
   "gender": "{{posting.API_4_10.gender}}",
   "age_restriction": {{posting.API_4_10.age_restriction}},
   "education_level": "{{posting.API_4_10.education_level}}",
-  "visa": "{{posting.API_4_10.visa}}",
+  "visa": "D_2, D_4",
   "recruiter_name": "{{posting.API_4_10.recruiter_name}}",
   "recruiter_email": "{{posting.API_4_10.recruiter_email}}",
   "recruiter_phone_number": "{{posting.API_4_10.recruiter_phone_number}}",

--- a/http/posting/PostControllerHttpRequest.http
+++ b/http/posting/PostControllerHttpRequest.http
@@ -23,7 +23,7 @@ Content-Type: application/json
 
 ### 4.2 (게스트) 공고 상세 조회하기
 // @no-log
-GET {{host_url}}/v1/guests/job-postings/{{posting.API_4_2.job_posting_id}}/details
+GET {{host_url}}/v1/guests/job-postings/2/details
 Content-Type: application/json
 
 
@@ -53,7 +53,7 @@ Authorization: Bearer {{access_token}}
 
 ### 4.4 (유학생/고용주) 공고 상세 조회하기
 // @no-log
-GET {{host_url}}/v1/job-postings/{{posting.API_4_4.job_posting_id}}/details
+GET {{host_url}}/v1/job-postings/2/details
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
@@ -79,7 +79,7 @@ Authorization: Bearer {{access_token}}
 
 ### 4.7 (유학생/고용주) 공고 요약 정보 조회하기
 // @no-log
-GET {{host_url}}/v1/job-postings/{{posting.API_4_7.job_posting_id}}/summaries
+GET {{host_url}}/v1/job-postings/2/summaries
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
@@ -141,7 +141,7 @@ Content-Type: application/json
   "gender": "{{posting.API_4_10.gender}}",
   "age_restriction": {{posting.API_4_10.age_restriction}},
   "education_level": "{{posting.API_4_10.education_level}}",
-  "visa": "{{posting.API_4_10.visa}}",
+  "visa": ["D_2","D_4"],
   "recruiter_name": "{{posting.API_4_10.recruiter_name}}",
   "recruiter_email": "{{posting.API_4_10.recruiter_email}}",
   "recruiter_phone_number": "{{posting.API_4_10.recruiter_phone_number}}",
@@ -153,27 +153,30 @@ Content-Type: application/json
 Content-Disposition: form-data; name="image"; filename="image1.png"
 Content-Type: image/png
 
-< /Users/kyeom/Desktop/updated-image.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 Content-Disposition: form-data; name="image"; filename="image2.png"
 Content-Type: image/png
 
-< /Users/kyeom/Desktop/updated-image.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 Content-Disposition: form-data; name="image"; filename="image3.png"
 Content-Type: image/png
 
-< /Users/kyeom/Desktop/updated-image.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 
 
 
+
+
+
 ### 4.11 (고용주) 공고 수정하기
 // @no-log
-PUT {{host_url}}/v1/owners/job-postings/{{posting.API_4_11.job_posting_id}}
+PUT {{host_url}}/v1/owners/job-postings/1
 Content-Type: multipart/form-data; boundary=boundary
 Authorization: Bearer {{access_token}}
 
@@ -214,7 +217,7 @@ Content-Type: application/json
   "gender": "{{posting.API_4_11.gender}}",
   "age_restriction": {{posting.API_4_11.age_restriction}},
   "education_level": "{{posting.API_4_11.education_level}}",
-  "visa": "{{posting.API_4_11.visa}}",
+  "visa": ["D_2","D_4"],
   "recruiter_name": "{{posting.API_4_11.recruiter_name}}",
   "recruiter_email": "{{posting.API_4_11.recruiter_email}}",
   "recruiter_phone_number": "{{posting.API_4_11.recruiter_phone_number}}",
@@ -229,19 +232,19 @@ Content-Type: application/json
 Content-Disposition: form-data; name="image"; filename="image1.png"
 Content-Type: image/png
 
-< /Users/jjuuuunnii/Desktop/image1.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 Content-Disposition: form-data; name="image"; filename="image2.png"
 Content-Type: image/png
 
-< /Users/jjuuuunnii/Desktop/image2.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 Content-Disposition: form-data; name="image"; filename="image3.png"
 Content-Type: image/png
 
-< /Users/jjuuuunnii/Desktop/image3.png
+< /Users/kyeom/Desktop/team13.png
 
 --boundary
 

--- a/src/main/java/com/inglo/giggle/core/type/EVisa.java
+++ b/src/main/java/com/inglo/giggle/core/type/EVisa.java
@@ -18,7 +18,9 @@ public enum EVisa {
     D_4_7("외국어연수", "D_4_7", "Foreign Language Trainee"),
     F_2("거주", "F_2", "Residence"),
     D_2("일반 유학과정", "D_2", "-"),
-    D_4("연수과정", "D_4", "-")
+    D_4("연수과정", "D_4", "-"),
+    D_10("구직", "D_10", "전문직 취업 준비"),
+    C_4("단기 취업", "C_4", "90일 이하 단기 근로")
 
     ;
 
@@ -40,6 +42,8 @@ public enum EVisa {
             case "D_2" -> D_2;
             case "D_4" -> D_4;
             case "F_2" -> F_2;
+            case "D_10" -> D_10;
+            case "C_4" -> C_4;
             default -> throw new IllegalArgumentException("비자가 잘못되었습니다.");
         };
     }

--- a/src/main/java/com/inglo/giggle/posting/application/controller/query/PostingGuestsQueryV1Controller.java
+++ b/src/main/java/com/inglo/giggle/posting/application/controller/query/PostingGuestsQueryV1Controller.java
@@ -1,6 +1,7 @@
 package com.inglo.giggle.posting.application.controller.query;
 
 import com.inglo.giggle.core.dto.ResponseDto;
+import com.inglo.giggle.core.type.EVisa;
 import com.inglo.giggle.posting.application.dto.request.ReadGuestJobPostingOverviewsRequestDto;
 import com.inglo.giggle.posting.application.dto.response.ReadGuestJobPostingDetailResponseDto;
 import com.inglo.giggle.posting.application.dto.response.ReadGuestJobPostingOverviewsResponseDto;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
 
 @Slf4j
 @RestController
@@ -40,7 +43,7 @@ public class PostingGuestsQueryV1Controller {
             @RequestParam(value = "working_hours", required = false) String workingHours,
             @RequestParam(value = "recruitment_period", required = false) String recruitmentPeriod,
             @RequestParam(value = "employment_type", required = false) String employmentType,
-            @RequestParam(value = "visa", required = false) String visa,
+            @RequestParam(value = "visa", required = false) Set<EVisa> visa,
             @RequestParam(value = "type", required = false) String type
     ) {
 

--- a/src/main/java/com/inglo/giggle/posting/application/controller/query/PostingQueryV1Controller.java
+++ b/src/main/java/com/inglo/giggle/posting/application/controller/query/PostingQueryV1Controller.java
@@ -2,6 +2,7 @@ package com.inglo.giggle.posting.application.controller.query;
 
 import com.inglo.giggle.core.annotation.security.AccountID;
 import com.inglo.giggle.core.dto.ResponseDto;
+import com.inglo.giggle.core.type.EVisa;
 import com.inglo.giggle.posting.application.dto.response.ReadJobPostingDetailResponseDto;
 import com.inglo.giggle.posting.application.dto.response.ReadJobPostingOverviewResponseDto;
 import com.inglo.giggle.posting.application.dto.response.ReadJobPostingSummariesResponseDto;
@@ -11,6 +12,7 @@ import com.inglo.giggle.posting.application.usecase.ReadJobPostingSummariesUseCa
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -42,7 +44,7 @@ public class PostingQueryV1Controller {
             @RequestParam(value = "working_hours", required = false) String workingHours,
             @RequestParam(value = "recruitment_period", required = false) String recruitmentPeriod,
             @RequestParam(value = "employment_type", required = false) String employmentType,
-            @RequestParam(value = "visa", required = false) String visa,
+            @RequestParam(value = "visa", required = false) Set<EVisa> visa,
             @RequestParam(value = "type", required = false) String type
     ) {
         if(type == null) {

--- a/src/main/java/com/inglo/giggle/posting/application/dto/request/CreateOwnerJobPostingRequestDto.java
+++ b/src/main/java/com/inglo/giggle/posting/application/dto/request/CreateOwnerJobPostingRequestDto.java
@@ -11,6 +11,7 @@ import com.inglo.giggle.posting.domain.type.EWorkPeriod;
 import jakarta.validation.constraints.*;
 
 import java.util.List;
+import java.util.Set;
 
 public record CreateOwnerJobPostingRequestDto(
 
@@ -68,7 +69,7 @@ public record CreateOwnerJobPostingRequestDto(
 
         @NotNull(message = "비자를 입력해주세요.")
         @JsonProperty("visa")
-        EVisa visa,
+        Set<EVisa> visa,
 
         @NotNull(message = "담당자명을 입력해주세요.")
         @Size(max = 10, message = "담당자명은 10자 이하로 입력해주세요.")

--- a/src/main/java/com/inglo/giggle/posting/application/dto/request/UpdateOwnerJobPostingRequestDto.java
+++ b/src/main/java/com/inglo/giggle/posting/application/dto/request/UpdateOwnerJobPostingRequestDto.java
@@ -11,6 +11,7 @@ import com.inglo.giggle.posting.domain.type.EWorkPeriod;
 import jakarta.validation.constraints.*;
 
 import java.util.List;
+import java.util.Set;
 
 public record UpdateOwnerJobPostingRequestDto(
 
@@ -67,7 +68,7 @@ public record UpdateOwnerJobPostingRequestDto(
 
         @NotNull(message = "비자 유형은 필수 입력 값입니다.")
         @JsonProperty("visa")
-        EVisa visa,
+        Set<EVisa> visa,
 
         @NotNull(message = "담당자 이름은 필수 입력 값입니다.")
         @Size(max = 10, message = "담당자 이름은 최대 10자까지 입력 가능합니다.")

--- a/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadGuestJobPostingDetailResponseDto.java
+++ b/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadGuestJobPostingDetailResponseDto.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Getter
 public class ReadGuestJobPostingDetailResponseDto extends SelfValidating<ReadGuestJobPostingDetailResponseDto> {
@@ -159,13 +160,13 @@ public class ReadGuestJobPostingDetailResponseDto extends SelfValidating<ReadGue
         private final Boolean isRecruiting;
 
         @JsonProperty("visa")
-        private final EVisa visa;
+        private final Set<EVisa> visa;
 
         @JsonProperty("job_category")
         private final EJobCategory jobCategory;
 
         @Builder
-        public Tags(Boolean isRecruiting, EVisa visa, EJobCategory jobCategory) {
+        public Tags(Boolean isRecruiting, Set<EVisa> visa, EJobCategory jobCategory) {
             this.isRecruiting = isRecruiting;
             this.visa = visa;
             this.jobCategory = jobCategory;
@@ -228,7 +229,7 @@ public class ReadGuestJobPostingDetailResponseDto extends SelfValidating<ReadGue
         private final Integer numberOfRecruits;
 
         @JsonProperty("visa")
-        private final EVisa visa;
+        private final Set<EVisa> visa;
 
         @JsonProperty("gender")
         private final String gender;
@@ -238,7 +239,7 @@ public class ReadGuestJobPostingDetailResponseDto extends SelfValidating<ReadGue
 
         @Builder
         public RecruitmentConditions(String recruitmentDeadline, String education, Integer numberOfRecruits,
-                                     EVisa visa, String gender, String preferredConditions) {
+                                     Set<EVisa> visa, String gender, String preferredConditions) {
             this.recruitmentDeadline = recruitmentDeadline;
             this.education = education;
             this.numberOfRecruits = numberOfRecruits;

--- a/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadJobPostingDetailResponseDto.java
+++ b/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadJobPostingDetailResponseDto.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Getter
 public class ReadJobPostingDetailResponseDto extends SelfValidating<ReadJobPostingDetailResponseDto> {
@@ -222,13 +223,13 @@ public class ReadJobPostingDetailResponseDto extends SelfValidating<ReadJobPosti
         private final Boolean isRecruiting;
 
         @JsonProperty("visa")
-        private final EVisa visa;
+        private final Set<EVisa> visa;
 
         @JsonProperty("job_category")
         private final EJobCategory jobCategory;
 
         @Builder
-        public Tags(Boolean isRecruiting, EVisa visa, EJobCategory jobCategory) {
+        public Tags(Boolean isRecruiting, Set<EVisa> visa, EJobCategory jobCategory) {
             this.isRecruiting = isRecruiting;
             this.visa = visa;
             this.jobCategory = jobCategory;
@@ -291,7 +292,7 @@ public class ReadJobPostingDetailResponseDto extends SelfValidating<ReadJobPosti
         private final Integer numberOfRecruits;
 
         @JsonProperty("visa")
-        private final EVisa visa;
+        private final Set<EVisa> visa;
 
         @JsonProperty("gender")
         private final String gender;
@@ -301,7 +302,7 @@ public class ReadJobPostingDetailResponseDto extends SelfValidating<ReadJobPosti
 
         @Builder
         public RecruitmentConditions(String recruitmentDeadline, String education, Integer numberOfRecruits,
-                                     EVisa visa, String gender, String preferredConditions) {
+                                     Set<EVisa> visa, String gender, String preferredConditions) {
             this.recruitmentDeadline = recruitmentDeadline;
             this.education = education;
             this.numberOfRecruits = numberOfRecruits;

--- a/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadUserBookMarkOverviewResponseDto.java
+++ b/src/main/java/com/inglo/giggle/posting/application/dto/response/ReadUserBookMarkOverviewResponseDto.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 public class ReadUserBookMarkOverviewResponseDto extends SelfValidating<ReadUserBookMarkOverviewResponseDto> {
@@ -158,14 +159,14 @@ public class ReadUserBookMarkOverviewResponseDto extends SelfValidating<ReadUser
 
             @NotNull(message = "visa는 null이 될 수 없습니다.")
             @JsonProperty("visa")
-            private final EVisa visa;
+            private final Set<EVisa> visa;
 
             @NotNull(message = "job_category는 null이 될 수 없습니다.")
             @JsonProperty("job_category")
             private final EJobCategory jobCategory;
 
             @Builder
-            public Tags(Boolean isRecruiting, EVisa visa, EJobCategory jobCategory) {
+            public Tags(Boolean isRecruiting, Set<EVisa> visa, EJobCategory jobCategory) {
                 this.isRecruiting = isRecruiting;
                 this.visa = visa;
                 this.jobCategory = jobCategory;

--- a/src/main/java/com/inglo/giggle/posting/application/service/ReadGuestJobPostingOverviewsService.java
+++ b/src/main/java/com/inglo/giggle/posting/application/service/ReadGuestJobPostingOverviewsService.java
@@ -26,6 +26,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -59,9 +60,8 @@ public class ReadGuestJobPostingOverviewsService implements ReadGuestJobPostingO
             String workingHours,
             String recruitmentPeriod,
             String employmentType,
-            String visa
+            Set<EVisa> visa
     ) {
-
         Pageable pageable = PageRequest.of(page - 1, size);
         LocalDate today = LocalDate.now();
 
@@ -142,7 +142,7 @@ public class ReadGuestJobPostingOverviewsService implements ReadGuestJobPostingO
                     today,
                     recruitmentPeriod,
                     employmentType == null ? null : EEmploymentType.fromString(employmentType),
-                    visa == null ? null : EVisa.fromString(visa),
+                    visa == null || visa.isEmpty() ? null : visa,
                     pageable
             );
         } else {
@@ -181,7 +181,7 @@ public class ReadGuestJobPostingOverviewsService implements ReadGuestJobPostingO
                     today,
                     recruitmentPeriod,
                     employmentType == null ? null : EEmploymentType.fromString(employmentType),
-                    visa == null ? null : EVisa.fromString(visa),
+                    visa == null || visa.isEmpty() ? null : visa,
                     pageable
             );
         }

--- a/src/main/java/com/inglo/giggle/posting/application/service/ReadJobPostingOverviewService.java
+++ b/src/main/java/com/inglo/giggle/posting/application/service/ReadJobPostingOverviewService.java
@@ -60,7 +60,7 @@ public class ReadJobPostingOverviewService implements ReadJobPostingOverviewUseC
             String workingHours,
             String recruitmentPeriod, // OPENED, CLOSED
             String employmentType,
-            String visa
+            Set<EVisa> visa
     ) {
         // Account 조회
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -143,7 +143,7 @@ public class ReadJobPostingOverviewService implements ReadJobPostingOverviewUseC
                     today,
                     recruitmentPeriod,
                     employmentType == null ? null : EEmploymentType.fromString(employmentType),
-                    visa == null ? null : EVisa.fromString(visa),
+                    visa == null || visa.isEmpty() ? null : visa,
                     pageable
             );
         } else {
@@ -182,7 +182,7 @@ public class ReadJobPostingOverviewService implements ReadJobPostingOverviewUseC
                     today,
                     recruitmentPeriod,
                     employmentType == null ? null : EEmploymentType.fromString(employmentType),
-                    visa == null ? null : EVisa.fromString(visa),
+                    visa == null || visa.isEmpty() ? null : visa,
                     pageable
             );
         }

--- a/src/main/java/com/inglo/giggle/posting/application/usecase/ReadGuestJobPostingOverviewsUseCase.java
+++ b/src/main/java/com/inglo/giggle/posting/application/usecase/ReadGuestJobPostingOverviewsUseCase.java
@@ -1,7 +1,10 @@
 package com.inglo.giggle.posting.application.usecase;
 
 import com.inglo.giggle.core.annotation.bean.UseCase;
+import com.inglo.giggle.core.type.EVisa;
 import com.inglo.giggle.posting.application.dto.response.ReadGuestJobPostingOverviewsResponseDto;
+
+import java.util.Set;
 
 @UseCase
 public interface ReadGuestJobPostingOverviewsUseCase {
@@ -42,7 +45,7 @@ public interface ReadGuestJobPostingOverviewsUseCase {
             String workingHours,
             String recruitmentPeriod,
             String employmentType,
-            String visa
+            Set<EVisa> visa
     );
 
 

--- a/src/main/java/com/inglo/giggle/posting/application/usecase/ReadJobPostingOverviewUseCase.java
+++ b/src/main/java/com/inglo/giggle/posting/application/usecase/ReadJobPostingOverviewUseCase.java
@@ -1,8 +1,10 @@
 package com.inglo.giggle.posting.application.usecase;
 
 import com.inglo.giggle.core.annotation.bean.UseCase;
+import com.inglo.giggle.core.type.EVisa;
 import com.inglo.giggle.posting.application.dto.response.ReadJobPostingOverviewResponseDto;
 
+import java.util.Set;
 import java.util.UUID;
 
 @UseCase
@@ -45,7 +47,7 @@ public interface ReadJobPostingOverviewUseCase {
             String workingHours,
             String recruitmentPeriod,
             String employmentType,
-            String visa
+            Set<EVisa> visa
     );
 
     /**

--- a/src/main/java/com/inglo/giggle/posting/domain/JobPosting.java
+++ b/src/main/java/com/inglo/giggle/posting/domain/JobPosting.java
@@ -67,9 +67,11 @@ public class JobPosting {
     @Column(name = "education_level", nullable = false)
     private EEducationLevel educationLevel;
 
+    @ElementCollection(targetClass = EVisa.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "job_posting_visas", joinColumns = @JoinColumn(name = "job_posting_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "visa")
-    private EVisa visa;
+    private Set<EVisa> visa = new HashSet<>();
 
     @Column(name = "recruiter_name", length = 10, nullable = false)
     private String recruiterName;
@@ -131,7 +133,7 @@ public class JobPosting {
     @Builder
     public JobPosting(String title, EJobCategory jobCategory, Integer hourlyRate, LocalDate recruitmentDeadLine,
                       EWorkPeriod workPeriod, Integer recruitmentNumber, EGender gender, Integer ageRestriction,
-                      EEducationLevel educationLevel, EVisa visa, String recruiterName, String recruiterEmail,
+                      EEducationLevel educationLevel, Set<EVisa> visa, String recruiterName, String recruiterEmail,
                       String recruiterPhoneNumber, String description, String preferredConditions,
                       EEmploymentType employmentType, Owner owner, Address address) {
         this.title = title;
@@ -165,7 +167,7 @@ public class JobPosting {
             EGender gender,
             Integer ageRestriction,
             EEducationLevel educationLevel,
-            EVisa visa,
+            Set<EVisa> visa,
             String recruiterName,
             String recruiterEmail,
             String recruiterPhoneNumber,

--- a/src/main/java/com/inglo/giggle/posting/domain/service/JobPostingService.java
+++ b/src/main/java/com/inglo/giggle/posting/domain/service/JobPostingService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 public class JobPostingService {
@@ -29,7 +30,7 @@ public class JobPostingService {
             EGender gender,
             Integer ageRestriction,
             EEducationLevel educationLevel,
-            EVisa visa,
+            Set<EVisa> visa,
             String recruiterName,
             String recruiterEmail,
             String recruiterPhoneNumber,
@@ -72,7 +73,7 @@ public class JobPostingService {
             EGender gender,
             Integer ageRestriction,
             EEducationLevel educationLevel,
-            EVisa visa,
+            Set<EVisa> visa,
             String recruiterName,
             String recruiterEmail,
             String recruiterPhoneNumber,


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #196 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 공고 등록 및 수정 시, 비자 다중으로 받도록 수정
API 명세 4.1, 4.2, 4.3, 4.4, 4.7, 4.10, 4.11 에 비자들어간 부분이 전부 바뀌었어요 (특히 상세조회부분은 visa가 두 번 등장하니 신경써주시면 감사하겠습니다)

조회같은 경우, visa를 다중으로 선택 가능하게 만들었습니다. 만약 D_2,D_4,C_4를 선택하면, 그 중 하나라도 포함되어있는 공고가 조회돼요

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
