### PR TITLE
🔨 Fix - 쿼리 변수가 포함된 NO_NEED_URL 적용 안되는 버그 수정

### DIFF
--- a/src/main/java/com/inglo/giggle/security/config/SecurityConfig.java
+++ b/src/main/java/com/inglo/giggle/security/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import com.inglo.giggle.security.handler.login.DefaultLoginSuccessHandler;
 import com.inglo.giggle.security.handler.logout.DefaultLogoutProcessHandler;
 import com.inglo.giggle.security.handler.logout.DefaultLogoutSuccessHandler;
 import com.inglo.giggle.security.application.usecase.AuthenticateJsonWebTokenUseCase;
+import com.inglo.giggle.security.matcher.CustomRegexRequestMatcher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,16 +60,16 @@ public class SecurityConfig {
                         .requestMatchers(
                                 Constants.REGEX_NO_NEED_AUTH_URLS
                                         .stream()
-                                        .map(pattern -> new RegexRequestMatcher(pattern, null))
-                                        .toArray(RegexRequestMatcher[]::new)
+                                        .map(CustomRegexRequestMatcher::new)
+                                        .toArray(CustomRegexRequestMatcher[]::new)
                         ).permitAll()
 
                         // USER 권한이 필요한 URL
                         .requestMatchers(
                                 Constants.REGEX_USER_URLS
                                         .stream()
-                                        .map(pattern -> new RegexRequestMatcher(pattern, null))
-                                        .toArray(RegexRequestMatcher[]::new)
+                                        .map(CustomRegexRequestMatcher::new)
+                                        .toArray(CustomRegexRequestMatcher[]::new)
                         ).hasAnyRole(ESecurityRole.USER.toString())
 
                         // OWNER 권한이 필요한 URL
@@ -83,24 +84,24 @@ public class SecurityConfig {
                         .requestMatchers(
                                 Constants.REGEX_ADMIN_URLS
                                         .stream()
-                                        .map(pattern -> new RegexRequestMatcher(pattern, null))
-                                        .toArray(RegexRequestMatcher[]::new)
+                                        .map(CustomRegexRequestMatcher::new)
+                                        .toArray(CustomRegexRequestMatcher[]::new)
                         ).hasAnyRole(ESecurityRole.ADMIN.toString())
 
                         // USER, OWNER 권한이 필요한 URL
                         .requestMatchers(
                                 Constants.REGEX_USER_OWNER_URLS
                                         .stream()
-                                        .map(pattern -> new RegexRequestMatcher(pattern, null))
-                                        .toArray(RegexRequestMatcher[]::new)
+                                        .map(CustomRegexRequestMatcher::new)
+                                        .toArray(CustomRegexRequestMatcher[]::new)
                         ).hasAnyRole(ESecurityRole.USER.toString(), ESecurityRole.OWNER.toString())
 
                         // USER, OWNER, ADMIN 권한이 필요한 URL
                         .requestMatchers(
                                 Constants.REGEX_USER_OWNER_ADMIN_URLS
                                         .stream()
-                                        .map(pattern -> new RegexRequestMatcher(pattern, null))
-                                        .toArray(RegexRequestMatcher[]::new)
+                                        .map(CustomRegexRequestMatcher::new)
+                                        .toArray(CustomRegexRequestMatcher[]::new)
                         ).hasAnyRole(ESecurityRole.USER.toString(), ESecurityRole.OWNER.toString(), ESecurityRole.ADMIN.toString())
 
                         // 모든 요청은 인증 필요

--- a/src/main/java/com/inglo/giggle/security/matcher/CustomRegexRequestMatcher.java
+++ b/src/main/java/com/inglo/giggle/security/matcher/CustomRegexRequestMatcher.java
@@ -1,0 +1,35 @@
+package com.inglo.giggle.security.matcher;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class CustomRegexRequestMatcher implements RequestMatcher {
+
+    private final String pattern;
+    private final boolean matchQueryString;
+
+    public CustomRegexRequestMatcher(String pattern) {
+        this.pattern = pattern;
+        this.matchQueryString = pattern.contains("\\?");
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (!matchQueryString) {
+            return uri.matches(pattern);
+        }
+        String query = request.getQueryString();
+        String fullUrl = (query != null && !query.isEmpty()) ? uri + "?" + query : uri;
+        fullUrl = URLDecoder.decode(fullUrl, StandardCharsets.UTF_8);
+        if (fullUrl.contains("?")) {
+            String[] parts = fullUrl.split("\\?", 2);
+            String queryPart = parts[1].replace("\"", "");
+            fullUrl = parts[0] + "?" + queryPart;
+        }
+        return fullUrl.matches(pattern);
+    }
+}
+

--- a/src/main/resources/application-krampoline.yml
+++ b/src/main/resources/application-krampoline.yml
@@ -19,7 +19,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #203 

어떤 변경사항이 있었나요?
- [ ] ✨ Feature: New feature
- [x] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- CustomRegexRequestMatcher 구현
이메일 중복 검증 엔드포인트인 /v1/auth/validations/email에 대해 no‑auth 처리가 되어야 하는데, 실제 요청에는 쿼리 스트링(?email=...)이 포함되어 있음에도 불구하고, Spring Security에서 기본으로 사용하는 RegexRequestMatcher는 HttpServletRequest.getRequestURI()만을 이용하여 매칭하기에, 정규식이 맞지 않다고 판단하여 permit시키지 않았습니다.
이에 CustomRegexRequestMatcher를 구현하여, 만약 해당 패턴이 쿼리파라미터를 포함하고 있다면, HttpServletRequest.getRequestURI() 에 더해서 파라미터에 대한 정규식 검증까지 수행하도록 구현했습니다.

```
package com.inglo.giggle.security.matcher;

import jakarta.servlet.http.HttpServletRequest;
import org.springframework.security.web.util.matcher.RequestMatcher;
import java.net.URLDecoder;
import java.nio.charset.StandardCharsets;

public class CustomRegexRequestMatcher implements RequestMatcher {

    private final String pattern;
    private final boolean matchQueryString;

    public CustomRegexRequestMatcher(String pattern) {
        this.pattern = pattern;
        this.matchQueryString = pattern.contains("\\?");
    }

    @Override
    public boolean matches(HttpServletRequest request) {
        String uri = request.getRequestURI();
        if (!matchQueryString) {
            return uri.matches(pattern);
        }
        String query = request.getQueryString();
        String fullUrl = (query != null && !query.isEmpty()) ? uri + "?" + query : uri;
        fullUrl = URLDecoder.decode(fullUrl, StandardCharsets.UTF_8);
        if (fullUrl.contains("?")) {
            String[] parts = fullUrl.split("\\?", 2);
            String queryPart = parts[1].replace("\"", "");
            fullUrl = parts[0] + "?" + queryPart;
        }
        return fullUrl.matches(pattern);
    }
}


```

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/e9e2c1b4-bcff-49dc-b5b1-c13a146c42cc" />


- 크램폴린 yml의 ddl-auto를 validate로 변경했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
없다면 N/A를 작성해주세요.
- [ ] 모든 API에 대한 테스트

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
