### PR TITLE
✨ Feature - AdminNotification Entity 구현

### DIFF
--- a/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
+++ b/src/main/java/com/inglo/giggle/banner/application/controller/command/BannerAdminCommandV1Controller.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/banners")
+@RequestMapping("/v1/admins/banners")
 public class BannerAdminCommandV1Controller {
 
     private final CreateAdminBannerUseCase createAdminBannerUseCase;

--- a/src/main/java/com/inglo/giggle/banner/application/dto/request/CreateAdminBannerRequestDto.java
+++ b/src/main/java/com/inglo/giggle/banner/application/dto/request/CreateAdminBannerRequestDto.java
@@ -6,6 +6,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateAdminBannerRequestDto(
+
+        @JsonProperty("title")
+        @NotBlank(message = "배너 제목은 필수입니다.")
+        String title,
+
         @JsonProperty("content")
         @NotBlank(message = "배너 내용은 필수입니다.")
         String content,

--- a/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/CreateAdminBannerService.java
@@ -37,12 +37,10 @@ public class CreateAdminBannerService implements CreateAdminBannerUseCase {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
 
-        // 계정 타입 유효성 검사
-        accountService.checkAdminValidation(account);
-
         String imgUrl = s3Util.uploadImageFile(image, account.getSerialId(), EImageType.BANNER_IMG);
 
         Banner banner = Banner.builder()
+                .title(requestDto.title())
                 .imgUrl(imgUrl)
                 .content(requestDto.content())
                 .role(requestDto.role())

--- a/src/main/java/com/inglo/giggle/banner/application/service/DeleteAdminBannerService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/DeleteAdminBannerService.java
@@ -2,11 +2,6 @@ package com.inglo.giggle.banner.application.service;
 
 import com.inglo.giggle.banner.application.usecase.DeleteAdminBannerUseCase;
 import com.inglo.giggle.banner.repository.mysql.BannerRepository;
-import com.inglo.giggle.core.exception.error.ErrorCode;
-import com.inglo.giggle.core.exception.type.CommonException;
-import com.inglo.giggle.security.domain.mysql.Account;
-import com.inglo.giggle.security.domain.service.AccountService;
-import com.inglo.giggle.security.repository.mysql.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,20 +11,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DeleteAdminBannerService implements DeleteAdminBannerUseCase {
 
-    private final AccountRepository accountRepository;
     private final BannerRepository bannerRepository;
-
-    private final AccountService accountService;
 
     @Override
     public void execute(UUID accountId, Long bannerId) {
-
-        // Account 조회
-        Account account = accountRepository.findById(accountId)
-                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RESOURCE));
-
-        // 계정 타입 유효성 검사
-        accountService.checkAdminValidation(account);
 
         bannerRepository.deleteById(bannerId);
     }

--- a/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerDetailService.java
+++ b/src/main/java/com/inglo/giggle/banner/application/service/ReadBannerDetailService.java
@@ -30,7 +30,7 @@ public class ReadBannerDetailService implements ReadBannerDetailUseCase {
         }
 
         // Banner 권한 확인
-        if (!banner.getRole().equals(role)) {
+        if (banner.getRole() != ESecurityRole.GUEST && !banner.getRole().equals(role)) {
             throw new CommonException(ErrorCode.ACCESS_DENIED);
         }
 

--- a/src/main/java/com/inglo/giggle/banner/domain/Banner.java
+++ b/src/main/java/com/inglo/giggle/banner/domain/Banner.java
@@ -28,6 +28,10 @@ public class Banner extends BaseEntity {
     /* -------------------------------------------- */
     /* Information Column ------------------------- */
     /* -------------------------------------------- */
+
+    @Column(name = "title", length = 50, nullable = false)
+    private String title;
+
     @Column(name = "img_url", length = 320, nullable = false)
     private String imgUrl;
 
@@ -43,7 +47,8 @@ public class Banner extends BaseEntity {
     /* Methods ------------------------------------ */
     /* -------------------------------------------- */
     @Builder
-    public Banner(String imgUrl, String content, ESecurityRole role) {
+    public Banner(String title, String imgUrl, String content, ESecurityRole role) {
+        this.title = title;
         this.imgUrl = imgUrl;
         this.content = content;
         this.role = role;

--- a/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
+++ b/src/main/java/com/inglo/giggle/banner/repository/mysql/BannerRepository.java
@@ -2,12 +2,16 @@ package com.inglo.giggle.banner.repository.mysql;
 
 import com.inglo.giggle.banner.domain.Banner;
 import com.inglo.giggle.security.domain.type.ESecurityRole;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long>{
-    List<Banner> findByRole(ESecurityRole role);
+
+    @Query("SELECT b FROM Banner b WHERE b.role = :role OR b.role = 'GUEST'")
+    List<Banner> findByRole(@Param("role") ESecurityRole role);
 }

--- a/src/main/java/com/inglo/giggle/notification/domain/AdminNotification.java
+++ b/src/main/java/com/inglo/giggle/notification/domain/AdminNotification.java
@@ -1,0 +1,60 @@
+package com.inglo.giggle.notification.domain;
+
+import com.inglo.giggle.core.dto.BaseEntity;
+import com.inglo.giggle.security.domain.type.ESecurityRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "admin_notifications")
+@SQLDelete(sql = "UPDATE admin_notifications SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class AdminNotification extends BaseEntity {
+
+    /* -------------------------------------------- */
+    /* Default Column ----------------------------- */
+    /* -------------------------------------------- */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /* -------------------------------------------- */
+    /* Information Column ------------------------- */
+    /* -------------------------------------------- */
+    @Column(name = "title", length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "message", length = 200, nullable = false)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private ESecurityRole role;
+
+    @Column(name = "is_advertisement", nullable = false)
+    private Boolean isAdvertisement;
+
+    /* -------------------------------------------- */
+    /* Method ------------------------------------ */
+    /* -------------------------------------------- */
+
+    @Builder
+    public AdminNotification(
+            String title,
+            String message,
+            ESecurityRole role,
+            Boolean isAdvertisement
+    ) {
+        this.title = title;
+        this.message = message;
+        this.role = role;
+        this.isAdvertisement = isAdvertisement;
+    }
+}

--- a/src/main/java/com/inglo/giggle/posting/domain/UserOwnerJobPosting.java
+++ b/src/main/java/com/inglo/giggle/posting/domain/UserOwnerJobPosting.java
@@ -49,6 +49,9 @@ public class UserOwnerJobPosting extends BaseEntity {
     @Column(name = "feedback", length = 200)
     private String feedback;
 
+    @Column(name = "memo", length = 200)
+    private String memo;
+
     /* -------------------------------------------- */
     /* Many To One Mapping ------------------------ */
     /* -------------------------------------------- */
@@ -97,5 +100,9 @@ public class UserOwnerJobPosting extends BaseEntity {
 
     public void updateResult(Boolean result) {
         this.result = result;
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
     }
 }

--- a/src/main/java/com/inglo/giggle/security/domain/type/ESecurityRole.java
+++ b/src/main/java/com/inglo/giggle/security/domain/type/ESecurityRole.java
@@ -9,8 +9,8 @@ public enum ESecurityRole {
 
     USER("유학생", "USER", "ROLE_USER"),
     OWNER("점주", "OWNER", "ROLE_OWNER"),
-    ADMIN("관리자", "ADMIN", "ROLE_ADMIN")
-
+    ADMIN("관리자", "ADMIN", "ROLE_ADMIN"),
+    GUEST("손님", "GUEST", "ROLE_GUEST")
     ;
 
     private final String koName;
@@ -22,6 +22,7 @@ public enum ESecurityRole {
             case "USER" -> USER;
             case "OWNER" -> OWNER;
             case "ADMIN" -> ADMIN;
+            case "GUEST" -> GUEST;
             default -> throw new IllegalArgumentException("Security Role이 잘못되었습니다.");
         };
     }

--- a/src/main/resources/application-krampoline.yml
+++ b/src/main/resources/application-krampoline.yml
@@ -19,7 +19,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #233 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [x] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- AdminNotification Entity 구현
![image](https://github.com/user-attachments/assets/3a3cef9f-5103-492f-a163-200c1c59fdd4)

- UserOwnerJobPosting에 memo 컬럼 추가
![image](https://github.com/user-attachments/assets/de541aea-c73b-43da-bdbd-bda083543dac)

- Banner에 title 컬럼 추가
![image](https://github.com/user-attachments/assets/ffcbbc04-6c25-4740-865a-8a8c2702da22)

- 어드민 배너 생성/삭제에 잘못된 엔드포인트 수정
![image](https://github.com/user-attachments/assets/9ceca08e-013d-4ef3-9f53-fe05f9a6503b)

- GUEST role 추가
![image](https://github.com/user-attachments/assets/3c2632df-0101-41ed-9404-b711e733ce4d)

- GUEST 권한의 배너의 경우, 유저와 오너 모두에게 조회되도록 수정
![image](https://github.com/user-attachments/assets/bacaf055-9a51-4115-8792-8c8efd8b00d9)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)

현재 ddl-auto가 create로 설정되어있습니다. 참고해주세요!!!!